### PR TITLE
set Loader on yaml.load to silence yaml loader warning

### DIFF
--- a/sumogsuitealertscollector/common/config.py
+++ b/sumogsuitealertscollector/common/config.py
@@ -75,7 +75,7 @@ class Config(object):
         config = {}
         with open(filepath, 'r') as stream:
             try:
-                config = yaml.load(stream)
+                config = yaml.load(stream, Loader=yaml.FullLoader)
             except yaml.YAMLError as exc:
                 log.error(f"Unable to read config {filepath} Error: {exc}")
         return config


### PR DESCRIPTION
Quick fix to silence the errors coming from yaml.load.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more info